### PR TITLE
Istio rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can test the rate limit feature in a new terminal using `curl` like so:
 <!-- This command sends 15 http requests in silent mode, outputting only the HTTP respnonse headers -->
 
 ```bash
-for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" http://192.168.56.90/; done
+for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" http://192.168.56.91/; done
 ```
 
 The first 10 requests should return a `200 - OK` response.

--- a/README.md
+++ b/README.md
@@ -236,23 +236,15 @@ This project implements request throttling using **Istio’s local rate limiting
 - **Status Code on Limit**: `429 Too Many Requests`  
 - **Implementation**: Istio `EnvoyFilter` (configured in `istio-rate-limit.yaml`)
 
-##### 🛠️ Enabling Rate Limiting
-
-To enable rate limiting, apply the provided Envoy filter configuration:
-
-```bash
-kubectl apply -f istio-rate-limit.yaml
-```
-
 ##### 🧪 How to Test
 
 You can test the rate limit feature in a new terminal using `curl` like so:
 
 <!-- This assumes the MetalLB LoadBalancer IP is not changed since the moment of writing this -->
 <!-- This command sends 15 http requests in silent mode, outputting only the HTTP respnonse headers -->
-<!--  -->
+
 ```bash
-for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" http://192.168.56.91/; done
+for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" http://192.168.56.90/; done
 ```
 
 The first 10 requests should return a `200 - OK` response.

--- a/README.md
+++ b/README.md
@@ -223,12 +223,47 @@ A `ServiceMonitor` is used for automatic metric discovery.
 
 ---
 
+### Assignment 5 - Istio Service Mesh
+
+#### 🚦 Rate Limiting via Istio
+
+This project implements request throttling using **Istio’s local rate limiting** feature, enforced at the Istio ingress gateway.
+
+##### ✅ Rate Limiting Details
+
+- **Limit**: 10 requests per minute  
+- **Scope**: Per client connection (typically per IP)  
+- **Status Code on Limit**: `429 Too Many Requests`  
+- **Implementation**: Istio `EnvoyFilter` (configured in `istio-rate-limit.yaml`)
+
+##### 🛠️ Enabling Rate Limiting
+
+To enable rate limiting, apply the provided Envoy filter configuration:
+
+```bash
+kubectl apply -f istio-rate-limit.yaml
+```
+
+##### 🧪 How to Test
+
+You can test the rate limit feature in a new terminal using `curl` like so:
+
+<!-- This assumes the MetalLB LoadBalancer IP is not changed since the moment of writing this -->
+<!-- This command sends 15 http requests in silent mode, outputting only the HTTP respnonse headers -->
+<!--  -->
+```bash
+for i in {1..15}; do curl -s -o /dev/null -w "%{http_code}\n" http://192.168.56.91/; done
+```
+
+The first 10 requests should return a `200 - OK` response.
+After the 10th request, subsequent responses should return a `429 - Too Many Requests` error.
+
+
 ## 📁 File Structure
 
 To be reorganized.
 
 ---
-
 
 ## 🗓️ Progress Log
 

--- a/VM/k8s/istio-rate-limit.yaml
+++ b/VM/k8s/istio-rate-limit.yaml
@@ -1,0 +1,45 @@
+# istio-rate-limit.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: ingressgateway-rate-limit
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        portNumber: 80
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.filters.http.local_ratelimit
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          stat_prefix: http_local_rate_limiter
+          token_bucket:
+            max_tokens: 10
+            tokens_per_fill: 10
+            fill_interval: 60s
+          filter_enabled:
+            runtime_key: local_rate_limit_enabled
+            default_value:
+              numerator: 100
+              denominator: HUNDRED
+          filter_enforced:
+            runtime_key: local_rate_limit_enforced
+            default_value:
+              numerator: 100
+              denominator: HUNDRED
+          response_headers_to_add:
+            - append: false
+              header:
+                key: x-local-rate-limit
+                value: 'true'

--- a/VM/k8s/istio-rate-limit.yaml
+++ b/VM/k8s/istio-rate-limit.yaml
@@ -1,5 +1,4 @@
-# istio-rate-limit.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: EnvoyFilter
 metadata:
   name: ingressgateway-rate-limit
@@ -9,37 +8,37 @@ spec:
     labels:
       istio: ingressgateway
   configPatches:
-  - applyTo: NETWORK_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        portNumber: 80
-        filterChain:
-          filter:
-            name: "envoy.filters.network.http_connection_manager"
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.http.local_ratelimit
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
-          stat_prefix: http_local_rate_limiter
-          token_bucket:
-            max_tokens: 10
-            tokens_per_fill: 10
-            fill_interval: 60s
-          filter_enabled:
-            runtime_key: local_rate_limit_enabled
-            default_value:
-              numerator: 100
-              denominator: HUNDRED
-          filter_enforced:
-            runtime_key: local_rate_limit_enforced
-            default_value:
-              numerator: 100
-              denominator: HUNDRED
-          response_headers_to_add:
-            - append: false
-              header:
-                key: x-local-rate-limit
-                value: 'true'
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          portNumber: 80
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              max_tokens: 10
+              tokens_per_fill: 10
+              fill_interval: 60s
+            filter_enabled:
+              runtime_key: local_rate_limit_enabled
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            filter_enforced:
+              runtime_key: local_rate_limit_enforced
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            response_headers_to_add:
+              - append: false
+                header:
+                  key: x-local-rate-limit
+                  value: 'true'

--- a/VM/provisioning/cluster-configuration.yml
+++ b/VM/provisioning/cluster-configuration.yml
@@ -10,6 +10,7 @@
         kubectl apply -f /vagrant/k8s/app.yaml
         kubectl apply -f /vagrant/k8s/monitoring.yaml
         kubectl apply -f /vagrant/k8s/ingress.yaml
+        kubectl apply -f /vagrant/k8s/istio-rate-limit.yaml
 
     # Enabling Prometheus
     # - name: Add Prometheus Community Helm repo

--- a/VM/provisioning/finalization.yml
+++ b/VM/provisioning/finalization.yml
@@ -88,6 +88,10 @@
         src: /tmp/istio.tar.gz
         dest: /home/vagrant/
         remote_src: yes
+        remote_src: yes
+        owner: vagrant
+        group: vagrant
+        mode: '0755'
 
     - name: Add istioctl to PATH
       lineinfile:
@@ -99,8 +103,6 @@
     - name: Run istioctl install (demo profile)
       shell: |
         /home/vagrant/istio-1.25.2/bin/istioctl install --set profile=demo -y
-      args:
-        creates: /home/vagrant/istio-1.25.2/manifests
 
     - name: Check Istio version
       shell: |


### PR DESCRIPTION
Rate limiting for Istio according to the documentation linked in the assignment:
https://istio.io/latest/docs/tasks/policy-enforcement/rate-limit/

Limit is set to 10 requests per minute per connection (not strictly by IP).

Details and a local testing setup are described in the repo README.

Please try to run from a clean pull. I would like to know whether I forgot to include a change I made to my local setup :)